### PR TITLE
Add Contaminated map to MapId enum

### DIFF
--- a/packages/cli/src/resources/prepare/types/config.ts
+++ b/packages/cli/src/resources/prepare/types/config.ts
@@ -19,6 +19,7 @@ export enum MapId {
 	Downtown = "MP_Granite_MainStreet_Portal-ModBuilderCustom0",
 	Area22B = "MP_Granite_MilitaryRnD_Portal-ModBuilderCustom0",
 	RedlineStorage = "MP_Granite_MilitaryStorage_Portal-ModBuilderCustom0",
+	Contaminated = "MP_Contaminated-ModBuilderCustom0",
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `Contaminated = "MP_Contaminated-ModBuilderCustom0"` to the `MapId` enum in the CLI config types
- Without this entry, `MapId.Contaminated` resolves to `undefined` at build time, causing the map rotation entry to silently lose its `id` field in `mod.json` — resulting in only one map showing up even when multiple maps are configured

## Test plan
- [x] `npm run build:cli` succeeds
- [x] All 19 existing tests pass
- [x] Verified that a mod project using `MapId.Contaminated` in `bf6.config.ts` now produces a correct `mod.json` with both maps having valid `id` fields in `mapRotation`